### PR TITLE
fix content-disposition value for attachment

### DIFF
--- a/Zip.php
+++ b/Zip.php
@@ -590,7 +590,7 @@ class Zip {
                 if ($inline) {
                     $cd .= "inline";
                 } else {
-                    $cd .= "attached";
+                    $cd .= "attachment";
                 }
                 if ($fileName) {
                     $cd .= '; filename="' . $fileName . '"';


### PR DESCRIPTION
Be compliant with RFC1806 for Content-Disposition header.

The current value "attached" caused problems with some devices.