### PR TITLE
Fix composer.json validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "keywords": ["epub", "e-book"],
     "homepage": "https://github.com/Grandt/PHPZip",
     "license": "LGPL-2.1",
-    "version": "4.0.6",
     "minimum-stability": "stable",
     "authors": [
         {
@@ -16,10 +15,10 @@
         }
     ],
     "require": {
-        "phpzip/phpzip": ">=2.0.7",
-        "grandt/phpresizegif": ">=1.0.4",
-        "grandt/relativepath": ">=1.0.1",
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "phpzip/phpzip": "~2.0.7",
+        "grandt/phpresizegif": "~1.0.3",
+        "grandt/relativepath": "~1.0.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See https://getcomposer.org/doc/04-schema.md for details on the schema

- The version field is present, it is recommended to leave it out if the package is published on Packagist.
- require.phpzip/phpzip : unbound version constraints (>=2.0.7) should be avoided
- require.grandt/phpresizegif : unbound version constraints (>=1.0.4) should be avoided
- require.grandt/relativepath : unbound version constraints (>=1.0.1) should be avoided

Also `grandt/phpresizegif` version 1.0.4 doesn't exist.