### PR TITLE
check that exif is installed instead of GD to use it

### DIFF
--- a/src/PHPePub/Helpers/ImageHelper.php
+++ b/src/PHPePub/Helpers/ImageHelper.php
@@ -253,7 +253,7 @@ class ImageHelper {
                     $width = ImageSX($imageFile);
                     $height = ImageSY($imageFile);
                 }
-                if (self::isGdInstalled()) {
+                if (self::isExifInstalled()) {
                     @$type = exif_imagetype($imageSource);
                     $mime = image_type_to_mime_type($type);
                 }


### PR DESCRIPTION
There's a call for an Exif function whereas it checks for GD.
