### PR TITLE
use HTML5-PHP

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+#### WhiteSource "Bolt for Github" configuration file ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=success

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "php": ">=5.3.0",
         "phpzip/phpzip": "~2.0.7",
         "grandt/phpresizegif": "~1.0.3",
-        "grandt/relativepath": "~1.0.1"
+        "grandt/relativepath": "~1.0.1",
+        "masterminds/html5": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/PHPePub/Core/EPub.php
+++ b/src/PHPePub/Core/EPub.php
@@ -2,6 +2,7 @@
 namespace PHPePub\Core;
 
 use com\grandt\BinStringStatic;
+use Masterminds\HTML5;
 use DOMDocument;
 use DOMXPath;
 use PHPePub\Core\Structure\Ncx;
@@ -358,8 +359,8 @@ class EPub {
      * @return array
      */
     function findIdAttributes($chapterData) {
-        $xmlDoc = new DOMDocument();
-        @$xmlDoc->loadHTML($chapterData);
+        $html5 = new HTML5();
+        $xmlDoc = $html5->loadHTML($chapterData);
 
         $xpath = new DomXpath($xmlDoc);
 
@@ -420,8 +421,8 @@ class EPub {
         if ($isDocAString) {
             $doc = StringHelper::removeComments($doc);
 
-            $xmlDoc = new DOMDocument();
-            @$xmlDoc->loadHTML($doc);
+            $html5 = new HTML5();
+            $xmlDoc = $html5->loadHTML($doc);
         } else {
             $xmlDoc = $doc;
         }

--- a/src/PHPePub/Core/EPubChapterSplitter.php
+++ b/src/PHPePub/Core/EPubChapterSplitter.php
@@ -1,6 +1,7 @@
 <?php
 namespace PHPePub\Core;
 
+use Masterminds\HTML5;
 use DOMDocument;
 
 /**
@@ -77,8 +78,8 @@ class EPubChapterSplitter {
             );
         }
 
-        $xmlDoc = new DOMDocument();
-        @$xmlDoc->loadHTML($chapter);
+        $html5 = new HTML5();
+        $xmlDoc = $html5->loadHTML($chapter);
 
         $head = $xmlDoc->getElementsByTagName("head");
         $body = $xmlDoc->getElementsByTagName("body");

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,7 +1,8 @@
 {
   "require": {
         "php": ">=5.3.0",
-        "phpzip/phpzip": ">=2.0.7"
+        "phpzip/phpzip": ">=2.0.7",
+        "masterminds/html5": "^2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Uses [html5-php](https://github.com/Masterminds/html5-php) parser for html5 compatibility. This avoids numerous warnings linked to php's DOMDocument not understanding new html5 tags.

I have tested this with a few cases but it may fail in some special cases.
