### PR TITLE
Fix #24 : Encoding special caracters for filename

### DIFF
--- a/src/PHPePub/Core/EPub.php
+++ b/src/PHPePub/Core/EPub.php
@@ -241,6 +241,7 @@ class EPub {
             return false;
         }
         $fileName = RelativePath::getRelativePath($fileName);
+        $fileName = FileHelper::sanitizeFileName($fileName);
         $fileName = preg_replace('#^[/\.]+#i', "", $fileName);
         $navPoint = false;
 

--- a/src/PHPePub/Core/StaticData.php
+++ b/src/PHPePub/Core/StaticData.php
@@ -278,7 +278,7 @@ class StaticData {
 
     public static $opsContentTypes = array("application/xhtml+xml", "application/x-dtbook+xml", "application/xml", "application/x-dtbncx+xml", "text/x-oeb1-document");
 
-    public static $forbiddenCharacters = array("?", "[", "]", "/", "\\", "=", "<", ">", ":", ";", ",", "'", "\"", "&", "$", "#", "*", "(", ")", "|", "~", "`", "!", "{", "}", "%");
+    public static $forbiddenCharacters = array("?", "[", "]", "/", "\\", "=", "<", ">", ":", ";", ",", "'", "\"", "&", "$", "#", "*", "(", ")", "|", "~", "`", "!", "{", "}", "%", "+");
 
     public static $namespaces = array("xsi" => "http://www.w3.org/2001/XMLSchema-instance",
                                       "opf" => "http://www.idpf.org/2007/opf",


### PR DESCRIPTION
#24 is a bit old, but the filename is still not sanitized. This PR use FileHelper::sanitizeFilename to fix that, and add `+` as a forbidden character (some Kobo device don't like it and ignore chapters with this characters in the filename).
