### PR TITLE
Typo on paragraph #18. URLs updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@ PHPePub allows a php script to generate ePub Electronic books on the fly, and se
 PHPePub support most of the ePub 2.01 specification, and enough of the new ePub3 specification to make valid ePub 3 books as well.
 
 The projects is also hosted on PHPClasses.org at the addresses:
-http://www.phpclasses.org/package/6115
+https://www.phpclasses.org/package/6115-PHP-Create-ebook-in-EPUB-format-for-ex-Apple-iPad.html
 
 PHPePub is meant to be easy to use for small projects, and still allow for comples and complete e-books should the need arise.
 
-The Zip.php class in this project originates from http://www.phpclasses.org/package/6110
+The Zip.php class in this project originates from https://www.phpclasses.org/package/6110-PHP-Create-archives-of-compressed-files-in-ZIP-format.html
 
-or on Github: git://github.com/Grandt/PHPZip.git
-
-See the examples for example usage. The php files have "some" doumentation in them in the form of Javadoc style function headers.
+or on Github: 
+```
+git://github.com/Grandt/PHPZip.git
+```
+See the examples for example usage. The php files have "some" documentation in them in the form of Javadoc style function headers.
 
 ## Installation
 


### PR DESCRIPTION
#18: `doumentation` > `documentation`